### PR TITLE
Add infrastructure layer with EF, logging and telemetry

### DIFF
--- a/src/Infrastructure/Data/AppDbContext.cs
+++ b/src/Infrastructure/Data/AppDbContext.cs
@@ -49,56 +49,48 @@ public class AppDbContext : DbContext
             builder.HasKey(p => p.Id);
 
             // Map skills collection stored in a separate table using the private backing field.
-            builder.OwnsMany<Skill>(
-                nameof(Profile.Skills),
-                sb =>
-                {
-                    sb.WithOwner().HasForeignKey("ProfileId");
-                    sb.Property<Guid>("Id");
-                    sb.HasKey("Id");
-                    sb.ToTable("ProfileSkills");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(p => p.Skills, sb =>
+            {
+                sb.WithOwner().HasForeignKey("ProfileId");
+                sb.Property<Guid>("Id");
+                sb.HasKey("Id");
+                sb.ToTable("ProfileSkills");
+            });
+            builder.Navigation(p => p.Skills)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
             // Education collection
-            builder.OwnsMany<EducationItem>(
-                nameof(Profile.Education),
-                eb =>
-                {
-                    eb.WithOwner().HasForeignKey("ProfileId");
-                    eb.Property<Guid>("Id");
-                    eb.HasKey("Id");
-                    eb.ToTable("ProfileEducation");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(p => p.Education, eb =>
+            {
+                eb.WithOwner().HasForeignKey("ProfileId");
+                eb.Property<Guid>("Id");
+                eb.HasKey("Id");
+                eb.ToTable("ProfileEducation");
+            });
+            builder.Navigation(p => p.Education)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
             // Experience collection
-            builder.OwnsMany<ExperienceItem>(
-                nameof(Profile.Experience),
-                exb =>
-                {
-                    exb.WithOwner().HasForeignKey("ProfileId");
-                    exb.Property<Guid>("Id");
-                    exb.HasKey("Id");
-                    exb.ToTable("ProfileExperience");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(p => p.Experience, exb =>
+            {
+                exb.WithOwner().HasForeignKey("ProfileId");
+                exb.Property<Guid>("Id");
+                exb.HasKey("Id");
+                exb.ToTable("ProfileExperience");
+            });
+            builder.Navigation(p => p.Experience)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
             // Languages collection
-            builder.OwnsMany<Language>(
-                nameof(Profile.Languages),
-                lb =>
-                {
-                    lb.WithOwner().HasForeignKey("ProfileId");
-                    lb.Property<Guid>("Id");
-                    lb.HasKey("Id");
-                    lb.ToTable("ProfileLanguages");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(p => p.Languages, lb =>
+            {
+                lb.WithOwner().HasForeignKey("ProfileId");
+                lb.Property<Guid>("Id");
+                lb.HasKey("Id");
+                lb.ToTable("ProfileLanguages");
+            });
+            builder.Navigation(p => p.Languages)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         // Map owned collections for Resume entity in a similar fashion.
@@ -106,41 +98,35 @@ public class AppDbContext : DbContext
         {
             builder.HasKey(r => r.Id);
 
-            builder.OwnsMany<Skill>(
-                nameof(Resume.Skills),
-                sb =>
-                {
-                    sb.WithOwner().HasForeignKey("ResumeId");
-                    sb.Property<Guid>("Id");
-                    sb.HasKey("Id");
-                    sb.ToTable("ResumeSkills");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(r => r.Skills, sb =>
+            {
+                sb.WithOwner().HasForeignKey("ResumeId");
+                sb.Property<Guid>("Id");
+                sb.HasKey("Id");
+                sb.ToTable("ResumeSkills");
+            });
+            builder.Navigation(r => r.Skills)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            builder.OwnsMany<EducationItem>(
-                nameof(Resume.Education),
-                eb =>
-                {
-                    eb.WithOwner().HasForeignKey("ResumeId");
-                    eb.Property<Guid>("Id");
-                    eb.HasKey("Id");
-                    eb.ToTable("ResumeEducation");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(r => r.Education, eb =>
+            {
+                eb.WithOwner().HasForeignKey("ResumeId");
+                eb.Property<Guid>("Id");
+                eb.HasKey("Id");
+                eb.ToTable("ResumeEducation");
+            });
+            builder.Navigation(r => r.Education)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            builder.OwnsMany<ExperienceItem>(
-                nameof(Resume.Experience),
-                exb =>
-                {
-                    exb.WithOwner().HasForeignKey("ResumeId");
-                    exb.Property<Guid>("Id");
-                    exb.HasKey("Id");
-                    exb.ToTable("ResumeExperience");
-                })
-                .Navigation
-                .SetPropertyAccessMode(PropertyAccessMode.Field);
+            builder.OwnsMany(r => r.Experience, exb =>
+            {
+                exb.WithOwner().HasForeignKey("ResumeId");
+                exb.Property<Guid>("Id");
+                exb.HasKey("Id");
+                exb.ToTable("ResumeExperience");
+            });
+            builder.Navigation(r => r.Experience)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
     }
 }

--- a/src/Infrastructure/Data/AppDbContext.cs
+++ b/src/Infrastructure/Data/AppDbContext.cs
@@ -1,0 +1,146 @@
+using System.Reflection;
+using JobCounselor.Domain.Entities;
+using JobCounselor.Domain.ValueObjects;
+using JobCounselor.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace JobCounselor.Infrastructure.Data;
+
+/// <summary>
+/// Entity Framework Core database context for the application.
+/// </summary>
+public class AppDbContext : DbContext
+{
+    /// <summary>
+    /// Creates a new <see cref="AppDbContext"/> using the given options.
+    /// </summary>
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    // DbSets for aggregate roots
+    public DbSet<Profile> Profiles => Set<Profile>();
+    public DbSet<Resume> Resumes => Set<Resume>();
+    public DbSet<CoverLetter> CoverLetters => Set<CoverLetter>();
+    public DbSet<JobPosting> JobPostings => Set<JobPosting>();
+
+    /// <summary>
+    /// Configures the model by mapping domain entities to database tables
+    /// and applying value converters/owned types where necessary.
+    /// </summary>
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Apply configurations defined in this assembly via the fluent API.
+        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+
+        // Configure enum conversions.
+        var jobStageConverter = new EnumToStringConverter<JobStage>();
+        modelBuilder.Entity<JobPosting>()
+            .Property(j => j.Stage)
+            .HasConversion(jobStageConverter);
+
+        // Map owned collections for Profile entity.
+        modelBuilder.Entity<Profile>(builder =>
+        {
+            builder.HasKey(p => p.Id);
+
+            // Map skills collection stored in a separate table using the private backing field.
+            builder.OwnsMany<Skill>(
+                nameof(Profile.Skills),
+                sb =>
+                {
+                    sb.WithOwner().HasForeignKey("ProfileId");
+                    sb.Property<Guid>("Id");
+                    sb.HasKey("Id");
+                    sb.ToTable("ProfileSkills");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+
+            // Education collection
+            builder.OwnsMany<EducationItem>(
+                nameof(Profile.Education),
+                eb =>
+                {
+                    eb.WithOwner().HasForeignKey("ProfileId");
+                    eb.Property<Guid>("Id");
+                    eb.HasKey("Id");
+                    eb.ToTable("ProfileEducation");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+
+            // Experience collection
+            builder.OwnsMany<ExperienceItem>(
+                nameof(Profile.Experience),
+                exb =>
+                {
+                    exb.WithOwner().HasForeignKey("ProfileId");
+                    exb.Property<Guid>("Id");
+                    exb.HasKey("Id");
+                    exb.ToTable("ProfileExperience");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+
+            // Languages collection
+            builder.OwnsMany<Language>(
+                nameof(Profile.Languages),
+                lb =>
+                {
+                    lb.WithOwner().HasForeignKey("ProfileId");
+                    lb.Property<Guid>("Id");
+                    lb.HasKey("Id");
+                    lb.ToTable("ProfileLanguages");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+        });
+
+        // Map owned collections for Resume entity in a similar fashion.
+        modelBuilder.Entity<Resume>(builder =>
+        {
+            builder.HasKey(r => r.Id);
+
+            builder.OwnsMany<Skill>(
+                nameof(Resume.Skills),
+                sb =>
+                {
+                    sb.WithOwner().HasForeignKey("ResumeId");
+                    sb.Property<Guid>("Id");
+                    sb.HasKey("Id");
+                    sb.ToTable("ResumeSkills");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+
+            builder.OwnsMany<EducationItem>(
+                nameof(Resume.Education),
+                eb =>
+                {
+                    eb.WithOwner().HasForeignKey("ResumeId");
+                    eb.Property<Guid>("Id");
+                    eb.HasKey("Id");
+                    eb.ToTable("ResumeEducation");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+
+            builder.OwnsMany<ExperienceItem>(
+                nameof(Resume.Experience),
+                exb =>
+                {
+                    exb.WithOwner().HasForeignKey("ResumeId");
+                    exb.Property<Guid>("Id");
+                    exb.HasKey("Id");
+                    exb.ToTable("ResumeExperience");
+                })
+                .Navigation
+                .SetPropertyAccessMode(PropertyAccessMode.Field);
+        });
+    }
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using JobCounselor.Application.Interfaces;
+using JobCounselor.Infrastructure.Data;
+using JobCounselor.Infrastructure.Repositories;
+using JobCounselor.Infrastructure.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Serilog;
+
+namespace JobCounselor.Infrastructure;
+
+/// <summary>
+/// Extension methods for registering infrastructure services in the
+/// dependency injection container.
+/// </summary>
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Adds infrastructure services to the provided <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">Application configuration.</param>
+    /// <param name="environment">Current hosting environment.</param>
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        // Configure Entity Framework Core using the in-memory provider by default.
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseInMemoryDatabase("AppDb"));
+
+        // Register repositories.
+        services.AddScoped<IRepository<Profile>, EfRepository<Profile>>();
+        services.AddScoped<IProfileRepository, ProfileRepository>();
+
+        // Register the AI cover letter provider and associated HttpClient.
+        services.AddHttpClient<IAiCoverLetterProvider, OllamaCoverLetterProvider>();
+
+        // Configure data protection key persistence outside of Azure for local development.
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID")))
+        {
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(new DirectoryInfo("./keys"));
+        }
+        else
+        {
+            services.AddDataProtection();
+        }
+
+        // Setup Serilog for structured logging to console and rolling file.
+        Log.Logger = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
+            .WriteTo.Console(formatter: new Serilog.Formatting.Json.JsonFormatter())
+            .WriteTo.File("logs/log-.txt", rollingInterval: RollingInterval.Day)
+            .CreateLogger();
+
+        services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog());
+
+        // OpenTelemetry tracing and metrics with OTLP exporter.
+        services.AddOpenTelemetry()
+            .ConfigureResource(res => res.AddService("JobCounselor"))
+            .WithTracing(tracer =>
+            {
+                tracer.AddAspNetCoreInstrumentation();
+                tracer.AddEntityFrameworkCoreInstrumentation();
+                tracer.AddOtlpExporter(o => o.Endpoint = new Uri("http://tempo:4317"));
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation();
+                metrics.AddRuntimeInstrumentation();
+                metrics.AddProcessInstrumentation();
+                metrics.AddOtlpExporter(o => o.Endpoint = new Uri("http://tempo:4317"));
+            });
+
+        return services;
+    }
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using JobCounselor.Application.Interfaces;
 using JobCounselor.Infrastructure.Data;
 using JobCounselor.Infrastructure.Repositories;
 using JobCounselor.Infrastructure.Services;
+using JobCounselor.Domain.Entities;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -11,12 +11,17 @@
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -6,5 +6,18 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Repositories/EfRepository.cs
+++ b/src/Infrastructure/Repositories/EfRepository.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using JobCounselor.Infrastructure.Data;
+
+namespace JobCounselor.Infrastructure.Repositories;
+
+/// <summary>
+/// Generic Entity Framework based repository implementation.
+/// </summary>
+/// <typeparam name="T">Entity type.</typeparam>
+public class EfRepository<T> : IRepository<T> where T : class
+{
+    protected readonly AppDbContext _dbContext;
+    protected readonly DbSet<T> _dbSet;
+
+    /// <summary>
+    /// Initializes the repository with the provided <see cref="AppDbContext"/>.
+    /// </summary>
+    public EfRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+        _dbSet = _dbContext.Set<T>();
+    }
+
+    public IQueryable<T> Query() => _dbSet.AsQueryable();
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken)
+    {
+        await _dbSet.AddAsync(entity, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(T entity, CancellationToken cancellationToken)
+    {
+        _dbSet.Update(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<T?> GetByIdAsync(object id, CancellationToken cancellationToken)
+    {
+        return await _dbSet.FindAsync(new[] { id }, cancellationToken);
+    }
+}

--- a/src/Infrastructure/Repositories/IRepository.cs
+++ b/src/Infrastructure/Repositories/IRepository.cs
@@ -1,0 +1,30 @@
+using System.Linq.Expressions;
+
+namespace JobCounselor.Infrastructure.Repositories;
+
+/// <summary>
+/// Generic repository abstraction for CRUD operations on entities.
+/// </summary>
+/// <typeparam name="T">Entity type.</typeparam>
+public interface IRepository<T> where T : class
+{
+    /// <summary>
+    /// Adds the given entity to the data store.
+    /// </summary>
+    Task AddAsync(T entity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates the given entity in the data store.
+    /// </summary>
+    Task UpdateAsync(T entity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves an entity by its identifier using the provided key selector.
+    /// </summary>
+    Task<T?> GetByIdAsync(object id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns an <see cref="IQueryable{T}"/> for additional query composition.
+    /// </summary>
+    IQueryable<T> Query();
+}

--- a/src/Infrastructure/Repositories/ProfileRepository.cs
+++ b/src/Infrastructure/Repositories/ProfileRepository.cs
@@ -15,4 +15,10 @@ public class ProfileRepository : EfRepository<Profile>, IProfileRepository
     public ProfileRepository(AppDbContext context) : base(context)
     {
     }
+
+    /// <inheritdoc />
+    public Task<Profile?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return base.GetByIdAsync(id, cancellationToken);
+    }
 }

--- a/src/Infrastructure/Repositories/ProfileRepository.cs
+++ b/src/Infrastructure/Repositories/ProfileRepository.cs
@@ -1,0 +1,18 @@
+using JobCounselor.Application.Interfaces;
+using JobCounselor.Domain.Entities;
+using JobCounselor.Infrastructure.Data;
+
+namespace JobCounselor.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository providing data access for <see cref="Profile"/> entities.
+/// </summary>
+public class ProfileRepository : EfRepository<Profile>, IProfileRepository
+{
+    /// <summary>
+    /// Creates a new <see cref="ProfileRepository"/> instance.
+    /// </summary>
+    public ProfileRepository(AppDbContext context) : base(context)
+    {
+    }
+}

--- a/src/Infrastructure/Services/IAiCoverLetterProvider.cs
+++ b/src/Infrastructure/Services/IAiCoverLetterProvider.cs
@@ -1,0 +1,16 @@
+namespace JobCounselor.Infrastructure.Services;
+
+/// <summary>
+/// Abstraction for providers capable of generating cover letter text
+/// using an AI model.
+/// </summary>
+public interface IAiCoverLetterProvider
+{
+    /// <summary>
+    /// Generates cover letter text from the supplied prompt.
+    /// </summary>
+    /// <param name="prompt">Prompt describing the cover letter to create.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The generated cover letter text.</returns>
+    Task<string> GenerateAsync(string prompt, CancellationToken cancellationToken);
+}

--- a/src/Infrastructure/Services/OllamaCoverLetterProvider.cs
+++ b/src/Infrastructure/Services/OllamaCoverLetterProvider.cs
@@ -1,0 +1,43 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace JobCounselor.Infrastructure.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IAiCoverLetterProvider"/> using a local
+/// Ollama API instance.
+/// </summary>
+public class OllamaCoverLetterProvider : IAiCoverLetterProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OllamaCoverLetterProvider> _logger;
+    private const string Endpoint = "http://ollama:11434/api/generate";
+
+    /// <summary>
+    /// Initializes the provider with the supplied <see cref="HttpClient"/> and logger.
+    /// </summary>
+    public OllamaCoverLetterProvider(HttpClient httpClient, ILogger<OllamaCoverLetterProvider> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GenerateAsync(string prompt, CancellationToken cancellationToken)
+    {
+        var request = new { model = "llama3", prompt };
+
+        using var response = await _httpClient.PostAsJsonAsync(Endpoint, request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<OllamaResponse>(cancellationToken: cancellationToken);
+        var text = result?.Response ?? string.Empty;
+        _logger.LogInformation("Generated cover letter {Length} characters", text.Length);
+        return text;
+    }
+
+    private sealed class OllamaResponse
+    {
+        public string Response { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AppDbContext` with value converters and owned types
- set up Serilog, Data Protection, and OpenTelemetry via DI
- add generic repository pattern and profile repository
- add AI cover letter provider calling Ollama API
- update Infrastructure project references

## Testing
- `dotnet restore JobTrack.ResumeBuilder.sln`
- `dotnet test JobTrack.ResumeBuilder.sln`

------
https://chatgpt.com/codex/tasks/task_e_68414bca07a8832c9f8774900f88bc4b