### PR TITLE
Add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Files and directories that should not be copied into the Docker build context
+# when building the WebApi container. Keeping the context small speeds up builds.
+
+# Build output directories
+bin/
+obj/
+**/bin/
+**/obj/
+
+# Git repository metadata
+.git
+
+# Node packages (if any are added later)
+node_modules/
+
+# IDE settings
+.vscode/
+
+# Local SPA build output placeholder
+webdist/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# ---------------------------------------------------------------
+# Dockerfile for building the JobCounselor WebApi project.
+# This uses a multi-stage build to create a self-contained
+# executable targeting .NET 8 running on Linux.
+# ---------------------------------------------------------------
+
+# --- Build stage ------------------------------------------------
+# Use the .NET 8 SDK image to restore packages and publish the app
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# Set the working directory inside the container
+WORKDIR /src
+
+# Copy the entire repository into the build container
+COPY . .
+
+# Restore NuGet packages for the WebApi project
+RUN dotnet restore src/WebApi/WebApi.csproj
+
+# Publish the WebApi as a self-contained application for linux-x64
+RUN dotnet publish src/WebApi/WebApi.csproj \
+    -c Release \
+    -o /app/publish \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=false \
+    -p:SelfContained=true \
+    -r linux-x64 \
+    -p:IncludeNativeLibrariesForSelfExtract=true
+
+# --- Runtime stage ----------------------------------------------
+# Use the lightweight runtime-deps image since the app is self-contained
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0 AS runtime
+
+# Expose the port the application listens on
+EXPOSE 8080
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the published output from the build stage
+COPY --from=build /app/publish .
+
+# Run the application. The executable name matches the project name
+ENTRYPOINT ["./WebApi"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+# ---------------------------------------------------------------------------
+# docker-compose configuration for local development of JobCounselor.
+# This file defines the application API, database, LLM backend (Ollama),
+# a placeholder web server for the SPA frontend and an optional Tempo
+# instance for distributed tracing.
+# ---------------------------------------------------------------------------
+version: '3.9'
+
+services:
+  # ---------------------------- API service ------------------------------
+  api:
+    # Build the container using the provided Dockerfile
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: jobcounselor-api
+    ports:
+      - "8080:8080"     # expose API on localhost:8080
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+      - ConnectionStrings__Default=Host=db;Database=jobcounselor;Username=job;Password=jobpw
+    depends_on:
+      - db
+      - ollama
+
+  # --------------------------- Database service -------------------------
+  db:
+    image: postgres:16
+    container_name: jobcounselor-db
+    environment:
+      - POSTGRES_USER=job
+      - POSTGRES_PASSWORD=jobpw
+      - POSTGRES_DB=jobcounselor
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"    # expose Postgres
+
+  # ---------------------------- Ollama service --------------------------
+  ollama:
+    image: ollama/ollama:latest
+    container_name: jobcounselor-ollama
+    ports:
+      - "11434:11434"  # default Ollama port
+    volumes:
+      - ollama-data:/root/.ollama
+    command: ["ollama", "serve"]
+    environment:
+      # The model to download and serve
+      - OLLAMA_MODELS=llama3:8b-instruct
+
+  # ----------------------------- Web service ----------------------------
+  web:
+    image: nginx:alpine
+    container_name: jobcounselor-web
+    volumes:
+      # Placeholder volume where the SPA build will eventually reside
+      - ./webdist:/usr/share/nginx/html:ro
+    ports:
+      - "8081:80"      # frontend served on localhost:8081
+    depends_on:
+      - api
+
+  # ----------------------------- Tempo service -------------------------
+  tempo:
+    image: grafana/tempo:latest
+    container_name: jobcounselor-tempo
+    ports:
+      - "3200:3200"    # Tempo API port
+    # Additional configuration can be mounted here if desired
+
+volumes:
+  db-data:
+  ollama-data:
+


### PR DESCRIPTION
## Summary
- add Dockerfile for building the WebApi as a self-contained .NET 8 app
- add docker-compose configuration for API, Postgres, Ollama, a placeholder web server and optional Tempo
- add .dockerignore

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415ad4aa44832caf7144d0c7c49610